### PR TITLE
moon: add moonrepo configuration and GitHub Actions workflows

### DIFF
--- a/.github/workflows/moon-rp.yml
+++ b/.github/workflows/moon-rp.yml
@@ -1,0 +1,92 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+name: moon-rp
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - 'src/v/**'
+      - 'MODULE.bazel'
+      - 'MODULE.bazel.lock'
+      - '.bazelrc'
+      - '.bazelversion'
+      - 'bazel/**'
+      - '.moon/**'
+      - '.prototools'
+      - '.github/workflows/moon-rp.yml'
+  pull_request:
+    paths:
+      - 'src/v/**'
+      - 'MODULE.bazel'
+      - 'MODULE.bazel.lock'
+      - '.bazelrc'
+      - '.bazelversion'
+      - 'bazel/**'
+      - '.moon/**'
+      - '.prototools'
+      - '.github/workflows/moon-rp.yml'
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  test:
+    name: Test (${{ matrix.config }})
+    runs-on: blacksmith-32vcpu-ubuntu-2404-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - config: release
+            task: rp:test
+          - config: debug
+            task: rp:test-debug
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: moonrepo/setup-toolchain@v0
+        with:
+          auto-install: true
+          cache-base: 'dev'
+
+      - uses: useblacksmith/setup-bazel@v2
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}-${{ matrix.config }}
+          repository-cache: true
+          external-cache: true
+          bazelrc: |
+            build --color=yes
+            build --show_timestamps
+
+      - name: Test
+        run: moon run ${{ matrix.task }} --color
+
+  lint:
+    name: Lint (Buildifier)
+    runs-on: blacksmith-32vcpu-ubuntu-2404-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: moonrepo/setup-toolchain@v0
+        with:
+          auto-install: true
+          cache-base: 'dev'
+
+      - uses: useblacksmith/setup-bazel@v2
+        with:
+          bazelisk-cache: true
+          repository-cache: true
+          bazelrc: |
+            build --color=yes
+
+      - name: Lint
+        run: moon run rp:lint --color

--- a/.github/workflows/moon-rpk.yml
+++ b/.github/workflows/moon-rpk.yml
@@ -1,0 +1,61 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+name: moon-rpk
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - 'src/go/rpk/**'
+      - '.moon/**'
+      - '.prototools'
+      - 'moon.yml'
+      - '.github/workflows/moon-rpk.yml'
+  pull_request:
+    paths:
+      - 'src/go/rpk/**'
+      - '.moon/**'
+      - '.prototools'
+      - 'moon.yml'
+      - '.github/workflows/moon-rpk.yml'
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  rpk:
+    name: RPK
+    runs-on: blacksmith-16vcpu-ubuntu-2404-arm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: moonrepo/setup-toolchain@v0
+        with:
+          auto-install: true
+          cache-base: 'dev'
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('src/go/rpk/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Build
+        run: moon run rpk:build --color
+
+      - name: Test
+        run: moon run rpk:test --color
+
+      - name: Lint
+        run: moon run rpk:lint --color

--- a/.gitignore
+++ b/.gitignore
@@ -286,3 +286,4 @@ bazel_cc_flags.json
 
 # claude local settings
 **/.claude/settings.local.json
+.moon/cache

--- a/.moon/toolchain.yml
+++ b/.moon/toolchain.yml
@@ -1,0 +1,9 @@
+$schema: 'https://moonrepo.dev/schemas/toolchain.json'
+
+rust:
+  version: '1.75.0'
+
+python:
+  packageManager: 'uv'
+  uv:
+    version: '0.5.26'

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -1,0 +1,10 @@
+$schema: 'https://moonrepo.dev/schemas/workspace.json'
+
+projects:
+  root: '.'
+  rp: 'src/v'
+  rpk: 'src/go/rpk'
+
+vcs:
+  manager: 'git'
+  defaultBranch: 'dev'

--- a/.prototools
+++ b/.prototools
@@ -1,0 +1,12 @@
+# Core toolchains managed by proto
+go = "1.24.3"
+rust = "1.75.0"
+node = "20.11.0"
+uv = "0.5.26"
+golangci-lint = "1.64.8"
+
+# Third-party plugins
+[plugins.tools]
+golangci-lint = "https://raw.githubusercontent.com/b4nst/proto-plugins/refs/heads/main/toml/golangci-lint.toml"
+
+# Bazel is auto-managed via .bazelversion

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Redpanda is the most complete, Apache Kafka®-compatible streaming data platform
     - [macOS](#macos)
     - [Other Linux environments](#other-linux-environments)
   - [Build manually](#build-manually)
+  - [Development with moonrepo](#development-with-moonrepo)
   - [Release candidate builds](#release-candidate-builds)
     - [RC releases on Debian/Ubuntu](#rc-releases-on-debianubuntu)
     - [RC releases on Fedora/RedHat/Amazon Linux](#rc-releases-on-fedoraredhatamazon-linux)
@@ -100,6 +101,71 @@ bazel build --config=release //...
 ```
 
 For more build configurations, see `.bazelrc`.
+
+## Development with moonrepo
+
+Redpanda uses [moonrepo](https://moonrepo.dev/) for development task orchestration. This provides a consistent developer experience with automatic toolchain management.
+
+### Quick Start
+
+```bash
+# Run bootstrap to install all toolchains to vbuild/
+./scripts/bootstrap.sh
+
+# Source the environment (or add to your shell profile)
+source scripts/env.sh
+
+# Verify environment
+moon run :check-env
+```
+
+All tools are installed within the repository under `vbuild/`:
+- `vbuild/proto/` - proto toolchain manager and managed tools (go, rust, uv, node)
+- `vbuild/bazelisk/` - bazelisk (Bazel version manager)
+
+### Common Tasks
+
+```bash
+# Build everything
+moon run :build
+
+# Build specific projects
+moon run rp:build            # C++ core (Bazel)
+moon run rpk:build           # RPK CLI (Go)
+
+# Run tests
+moon run :test               # All tests
+moon run rp:test             # C++ tests
+moon run rpk:test            # RPK tests
+
+# Linting
+moon run :lint               # All linters
+moon run rpk:lint            # Go linting
+
+# Ducktape integration tests
+moon run tests:ducktape      # Full test suite
+moon run tests:ducktape-quick # Quick tests
+```
+
+### Build Configurations
+
+For C++ builds, use the appropriate task for your configuration:
+
+```bash
+moon run rp:build        # Release build (default)
+moon run rp:build-debug  # Debug build
+moon run rp:build-fast   # Fast build (no optimizations)
+```
+
+### Project Structure
+
+| Project | Location | Description |
+|---------|----------|-------------|
+| `rp` | `src/v` | C++ core (Bazel) |
+| `rpk` | `src/go/rpk` | RPK CLI (Go) |
+| `transform-sdk-rust` | `src/transform-sdk/rust` | Rust transform SDK |
+| `transform-sdk-js` | `src/transform-sdk/js` | JS transform SDK |
+| `tests` | `tests` | Ducktape integration tests |
 
 ## Release candidate builds
 

--- a/moon.yml
+++ b/moon.yml
@@ -1,0 +1,30 @@
+$schema: 'https://moonrepo.dev/schemas/project.json'
+type: 'tool'
+language: 'other'
+
+tasks:
+  build:
+    deps: ['rp:build', 'rpk:build']
+
+  test:
+    deps: ['rp:test', 'rpk:test']
+
+  lint:
+    deps: ['rp:lint', 'rpk:lint']
+
+  # Full bootstrap (for fresh machines)
+  bootstrap:
+    command: './scripts/bootstrap.sh'
+    local: true
+
+  # Environment check
+  check-env:
+    script: |
+      echo "Checking development environment..." &&
+      (command -v moon || (echo "moon not found" && exit 1)) &&
+      (command -v go || (echo "go not found" && exit 1)) &&
+      (command -v uv || (echo "uv not found" && exit 1)) &&
+      (command -v cargo || (echo "cargo not found" && exit 1)) &&
+      (command -v bazel || (echo "bazel not found" && exit 1)) &&
+      echo "Environment OK!"
+    local: true

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+set -e
+
+echo "=== Redpanda Development Environment Bootstrap ==="
+
+# Get the repo root (parent of scripts/)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Build root - all tools go here
+BUILD_ROOT="${BUILD_ROOT:-$REPO_ROOT/vbuild}"
+PROTO_HOME="$BUILD_ROOT/proto"
+BAZELISK_VERSION="1.25.0"
+BAZELISK_INSTALL_DIR="$BUILD_ROOT/bazelisk/$BAZELISK_VERSION"
+
+# Detect architecture
+ARCH=$(uname -m)
+case $ARCH in
+  x86_64) ARCH_SUFFIX="amd64" ;;
+  aarch64) ARCH_SUFFIX="arm64" ;;
+  *) echo "Unsupported architecture: $ARCH" && exit 1 ;;
+esac
+
+# 1. Minimal system dependencies
+echo "Installing minimal system packages..."
+if [ -f /etc/os-release ]; then
+  source /etc/os-release
+  case $ID in
+    ubuntu | debian)
+      sudo apt update
+      sudo apt install -y curl git ca-certificates wget
+
+      # Install Docker CE if not present
+      if ! command -v docker &>/dev/null; then
+        sudo install -m 0755 -d /etc/apt/keyrings
+        curl -fsSL https://download.docker.com/linux/$ID/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+        sudo chmod a+r /etc/apt/keyrings/docker.gpg
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/$ID $(. /etc/os-release && echo $VERSION_CODENAME) stable" | sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+        sudo apt update
+        sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+        sudo usermod -aG docker $USER
+      fi
+      ;;
+    fedora)
+      sudo dnf install -y curl git ca-certificates dnf-plugins-core wget
+      if ! command -v docker &>/dev/null; then
+        sudo dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
+        sudo dnf install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+        sudo systemctl enable --now docker
+        sudo usermod -aG docker $USER
+      fi
+      ;;
+    *)
+      echo "Unsupported OS: $ID. Install curl, git, wget, docker CE manually."
+      ;;
+  esac
+fi
+
+# 2. Install bazelisk (Bazel version manager)
+echo "Installing bazelisk to $BAZELISK_INSTALL_DIR..."
+mkdir -p "$BAZELISK_INSTALL_DIR/bin"
+if [ ! -f "$BAZELISK_INSTALL_DIR/bin/bazel" ]; then
+  wget -q -O "$BAZELISK_INSTALL_DIR/bin/bazel" "https://github.com/bazelbuild/bazelisk/releases/download/v$BAZELISK_VERSION/bazelisk-linux-$ARCH_SUFFIX"
+  chmod +x "$BAZELISK_INSTALL_DIR/bin/bazel"
+fi
+export PATH="$BAZELISK_INSTALL_DIR/bin:$PATH"
+
+# 3. Install proto (toolchain manager) to vbuild/proto
+export PROTO_HOME="$PROTO_HOME"
+if [ ! -f "$PROTO_HOME/bin/proto" ]; then
+  echo "Installing proto to $PROTO_HOME..."
+  curl -fsSL https://moonrepo.dev/install/proto.sh | bash -s -- --yes --no-profile
+fi
+export PATH="$PROTO_HOME/bin:$PATH"
+
+# 4. Install moon via proto
+echo "Installing moon..."
+proto install moon
+
+# 5. Install all toolchains via proto (reads .prototools)
+echo "Installing toolchains via proto..."
+cd "$REPO_ROOT"
+proto use
+
+# 6. Setup PATH
+echo ""
+echo "=== Add to your ~/.bashrc or ~/.zshrc ==="
+echo "# Redpanda development environment"
+echo 'export PROTO_HOME="$HOME/src/redpanda/vbuild/proto"  # Adjust path to your repo'
+cat <<'SHELL_CONFIG'
+export PATH="$PROTO_HOME/shims:$PROTO_HOME/bin:$HOME/src/redpanda/vbuild/bazelisk/1.25.0/bin:$PATH"
+SHELL_CONFIG
+echo ""
+echo "Or source the environment script:"
+echo "  source $REPO_ROOT/scripts/env.sh"
+
+# 7. Create env.sh for easy sourcing
+cat >"$REPO_ROOT/scripts/env.sh" <<EOF
+# Redpanda development environment
+# Source this file: source scripts/env.sh
+
+SCRIPT_DIR="\$(cd "\$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="\$(cd "\$SCRIPT_DIR/.." && pwd)"
+BUILD_ROOT="\${BUILD_ROOT:-\$REPO_ROOT/vbuild}"
+
+export PROTO_HOME="\$BUILD_ROOT/proto"
+export PATH="\$PROTO_HOME/shims:\$PROTO_HOME/bin:\$BUILD_ROOT/bazelisk/1.25.0/bin:\$PATH"
+
+# Rust toolchain (installed by proto)
+if [ -d "\$PROTO_HOME/tools/rust" ]; then
+  export PATH="\$PROTO_HOME/tools/rust/*/bin:\$PATH"
+fi
+EOF
+
+# 8. Verify
+echo ""
+echo "Verifying installation..."
+proto status
+moon --version
+go version
+uv --version
+"$PROTO_HOME/tools/rust/1.75.0/bin/cargo" --version || cargo --version 2>/dev/null || echo "cargo: check PATH after sourcing env.sh"
+bazel --version
+
+echo ""
+echo "=== Bootstrap complete! ==="
+echo "NOTE: Log out and back in for docker group to take effect"
+echo ""
+echo "To use the development environment, run:"
+echo "  source $REPO_ROOT/scripts/env.sh"
+echo ""
+echo "Then run: moon run :build"

--- a/src/go/rpk/moon.yml
+++ b/src/go/rpk/moon.yml
@@ -1,0 +1,24 @@
+$schema: 'https://moonrepo.dev/schemas/project.json'
+type: 'application'
+language: 'go'
+platform: 'system'
+
+fileGroups:
+  sources: ['**/*.go', 'go.mod', 'go.sum']
+
+tasks:
+  build:
+    command: 'go build -o bin/rpk ./cmd/rpk'
+    inputs: ['@group(sources)']
+    outputs: ['bin/rpk']
+
+  test:
+    command: 'go test ./...'
+    inputs: ['@group(sources)']
+
+  lint:
+    command: 'golangci-lint run --timeout 8m'
+    inputs: ['@group(sources)', '.golangci.yml']
+
+  fmt:
+    command: 'gofumpt -w -lang=1.23 .'

--- a/src/v/moon.yml
+++ b/src/v/moon.yml
@@ -1,0 +1,76 @@
+$schema: 'https://moonrepo.dev/schemas/project.json'
+type: 'application'
+language: 'other'
+platform: 'system'
+
+fileGroups:
+  sources: ['**/*.cc', '**/*.h', '**/BUILD']
+
+tasks:
+  # System setup - ensure AIO limits are sufficient for builds/tests
+  set-aio-max:
+    script: |
+      MIN_REQUIRED=20971520
+      if [ ! -f /proc/sys/fs/aio-max-nr ]; then
+        echo "fs.aio-max-nr not available (non-Linux or container without /proc)"
+        exit 0
+      fi
+      CURRENT=$(/sbin/sysctl -nb fs.aio-max-nr 2>/dev/null || cat /proc/sys/fs/aio-max-nr)
+      if [ "$CURRENT" -lt "$MIN_REQUIRED" ]; then
+        echo "Setting fs.aio-max-nr from $CURRENT to $MIN_REQUIRED (requires sudo)"
+        if command -v sudo >/dev/null 2>&1; then
+          sudo sysctl -w fs.aio-max-nr=$MIN_REQUIRED
+        else
+          echo "Warning: sudo not available, cannot set fs.aio-max-nr"
+          echo "Run manually: sysctl -w fs.aio-max-nr=$MIN_REQUIRED"
+        fi
+      else
+        echo "fs.aio-max-nr=$CURRENT (sufficient)"
+      fi
+    options:
+      cache: false
+
+  # Default build (release)
+  build:
+    command: 'bazel build --config=release --config=stamp //...'
+    deps: ['set-aio-max']
+    inputs: ['@group(sources)', '/MODULE.bazel', '/.bazelrc', '/bazel/**/*']
+    options:
+      runFromWorkspaceRoot: true
+
+  # Debug build
+  build-debug:
+    command: 'bazel build --config=debug --config=stamp //...'
+    deps: ['set-aio-max']
+    inputs: ['@group(sources)', '/MODULE.bazel', '/.bazelrc', '/bazel/**/*']
+    options:
+      runFromWorkspaceRoot: true
+
+  # Fast build (no optimizations)
+  build-fast:
+    command: 'bazel build --config=fastbuild //...'
+    deps: ['set-aio-max']
+    inputs: ['@group(sources)', '/MODULE.bazel', '/.bazelrc', '/bazel/**/*']
+    options:
+      runFromWorkspaceRoot: true
+
+  # Default test (release)
+  test:
+    command: 'bazel test --config=release //...'
+    deps: ['set-aio-max']
+    inputs: ['@group(sources)', '/MODULE.bazel', '/.bazelrc', '/bazel/**/*']
+    options:
+      runFromWorkspaceRoot: true
+
+  # Debug test
+  test-debug:
+    command: 'bazel test --config=debug //...'
+    deps: ['set-aio-max']
+    inputs: ['@group(sources)', '/MODULE.bazel', '/.bazelrc', '/bazel/**/*']
+    options:
+      runFromWorkspaceRoot: true
+
+  lint:
+    command: 'bazel run //tools:buildifier.check'
+    options:
+      runFromWorkspaceRoot: true


### PR DESCRIPTION
## Summary

- Add moonrepo workspace and toolchain configuration for managing the monorepo build
- Add bootstrap script for developer environment setup
- Add moon project configurations for core components (rp, rpk)
- Add GitHub Actions workflows with Blacksmith ARM runners for faster CI:
  - `moon-rpk.yml` - Go CLI build, test, and lint
  - `moon-rp.yml` - C++ Bazel tests (release + debug) and lint

## Key Features

- **Blacksmith ARM runners** for faster and more economical builds with sticky disk caching
- **Moon task orchestration** for consistent build commands
- **Proto toolchain management** via `.prototools` for reproducible environments
- **Path-based workflow triggers** - workflows only run when relevant files change

## Test plan

- [ ] PR touching only `src/go/rpk/**` → only `moon-rpk.yml` runs
- [ ] PR touching only `src/v/**` → only `moon-rp.yml` runs
- [ ] Verify Blacksmith sticky disk caching works (check "Restoring cache" logs)
- [ ] Verify proto toolchain cache restores
- [ ] Verify Go modules cache works